### PR TITLE
Fix bug causing init.php to fail

### DIFF
--- a/dist/data/db_03_user_table.sql
+++ b/dist/data/db_03_user_table.sql
@@ -35,7 +35,7 @@ START TRANSACTION;
 
 INSERT INTO saas_bread.users(id, given_name, family_name, email, age, gender, location)
 VALUES
-    (20, 'Jacques', 'd\'Carre' 'jacques@example.com', 0, 'O', 'Paris, France'),
+    (20, 'Jacques', 'd\'Carre', 'jacques@example.com', 0, 'O', 'Paris, France'),
     (null, 'Eileen', 'Dover', 'eileen@example.com', 0, 'f', 'Dover, UK'),
     (null, 'Robin', 'Money', 'Robin.Money@example.com', 83, 'T', 'Sawākin, SD'),
     (null, 'Manuel', 'Transmission', 'Manuel.Transmission@example.com', 97, 'F', 'Kalandia, PS'),

--- a/dist/data/init.php
+++ b/dist/data/init.php
@@ -87,7 +87,7 @@ $users = [
 
 
 try {
-    require_once "../db.php";
+    require_once "../config/db.php";
     $connection = new PDO($dsn, $dbUser, $dbPass, $dbOptions);
     echo "<h4>Adding Seed Users Data</h4>";
 


### PR DESCRIPTION
When running /data/init.php, the following error message would be given:
```
Insert value list does not match column list: 1136 Column count doesn't match value count at row 1
```
This is caused by a missing comma in db_03_user_table.sql. When the comma is added, a second bug occurs:
```
Warning: require_once(../db.php): failed to open stream: No such file or directory in C:\Users\...\Desktop\SaaS-BREAD-1\dist\data\init.php on line 90

Fatal error: require_once(): Failed opening required '../db.php' (include_path='.;C:/ProgramData/Laragon/etc/php/pear') in C:\Users\...\Desktop\SaaS-BREAD-1\dist\data\init.php on line 90
```
This is caused by an incorrect path when including the db config. Both bugs have been fixed in this pull request.